### PR TITLE
Add Japanese (ja-JP) localization

### DIFF
--- a/PathCopyCopySettings/Properties/Resources.ja-JP.resx
+++ b/PathCopyCopySettings/Properties/Resources.ja-JP.resx
@@ -1,0 +1,425 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CYGWIN_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>Cygwinパスをコピー</value>
+  </data>
+  <data name="DEV_BUILD" xml:space="preserve">
+    <value> (開発版)</value>
+  </data>
+  <data name="EDITING_DISABLED_MESSAGE" xml:space="preserve">
+    <value>この機能は管理者によって無効化されています。</value>
+  </data>
+  <data name="EDITING_DISABLED_TITLE" xml:space="preserve">
+    <value>編集が無効化されています</value>
+  </data>
+  <data name="ImportPipelinePluginsForm_CantOverwriteGlobalMsg" xml:space="preserve">
+    <value>グレー表示されているカスタムコマンドは、管理者が設定したコマンドを上書きしてしまうため、選択できません。</value>
+  </data>
+  <data name="ImportPipelinePluginsForm_IncompatiblePluginsMsg" xml:space="preserve">
+    <value>バージョン要件が表示されているカスタムコマンドは、このバージョンのPath Copy Copyと互換性がありません。それでもインポートできますが、無効化されます。</value>
+  </data>
+  <data name="ImportPipelinePluginsForm_MsgTitle" xml:space="preserve">
+    <value>カスタムコマンド</value>
+  </data>
+  <data name="INTERNET_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>インターネット形式のパスをコピー</value>
+  </data>
+  <data name="Language_English_DisplayName" xml:space="preserve">
+    <value>英語</value>
+  </data>
+  <data name="Language_French_DisplayName" xml:space="preserve">
+    <value>フランス語</value>
+  </data>
+  <data name="Language_Japanese_DisplayName" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="LONG_FOLDER_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>親フォルダの長いパスをコピー</value>
+  </data>
+  <data name="LONG_NAME_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>長い名前をコピー</value>
+  </data>
+  <data name="LONG_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>長いパスをコピー</value>
+  </data>
+  <data name="LONG_UNC_FOLDER_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>親フォルダの長いUNCパスをコピー</value>
+  </data>
+  <data name="LONG_UNC_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>長いUNCパスをコピー</value>
+  </data>
+  <data name="MainForm_Confirm_EditMsgTitle" xml:space="preserve">
+    <value>編集</value>
+  </data>
+  <data name="MainForm_Confirm_ExportUserSettingsMsgTitle" xml:space="preserve">
+    <value>設定のエクスポート</value>
+  </data>
+  <data name="MainForm_Confirm_ExportUserSettingsSaving" xml:space="preserve">
+    <value>設定をエクスポートするには、まず変更を適用する必要があります。今すぐ変更を適用しますか?</value>
+  </data>
+  <data name="MainForm_Confirm_ImportMsgTitle" xml:space="preserve">
+    <value>インポート</value>
+  </data>
+  <data name="MainForm_Confirm_ImportPipelinePluginOverwrite" xml:space="preserve">
+    <value>インポートする一部のカスタムコマンドは、既存のコマンドを上書きします。それでもインポートしますか?</value>
+  </data>
+  <data name="MainForm_Error_ImportPipelinePluginBadXMLFormat" xml:space="preserve">
+    <value>カスタムコマンドをインポートしようとしてエラーが発生しました。ファイルが破損している可能性があります。</value>
+  </data>
+  <data name="MainForm_Error_ImportPipelinePluginEmptyXML" xml:space="preserve">
+    <value>カスタムコマンドをインポートしようとしてエラーが発生しました。ファイルが空のようです。</value>
+  </data>
+  <data name="MainForm_Error_InvalidPipelinePluginEncodedElements" xml:space="preserve">
+    <value>このカスタムコマンドのデータを解釈しようとしてエラーが発生しました。おそらく、より新しいバージョンのPath Copy Copyで作成されたものです。編集することはできません。</value>
+  </data>
+  <data name="MainForm_Msg_DataErrorMsgTitle" xml:space="preserve">
+    <value>エラー</value>
+  </data>
+  <data name="MainForm_Msg_LanguageSwitched" xml:space="preserve">
+    <value>アプリケーションの言語を変更するには、セッションを終了して再認証する必要があります。</value>
+  </data>
+  <data name="MainForm_Msg_LanguageSwitchedMsgTitle" xml:space="preserve">
+    <value>言語の変更</value>
+  </data>
+  <data name="MainForm_Msg_UserSettingsExported" xml:space="preserve">
+    <value>設定が"{0}"にエクスポートされました。再度インポートするには(別のマシンでも可能)、Windowsエクスプローラーで.regファイルをダブルクリックしてください。</value>
+  </data>
+  <data name="MainForm_Msg_UserSettingsExportedMsgTitle" xml:space="preserve">
+    <value>設定がエクスポートされました</value>
+  </data>
+  <data name="MainForm_Msg_UserSettingsNotExported" xml:space="preserve">
+    <value>設定を"{0}"にエクスポート中にエラーが発生しました。設定は正常にエクスポートされませんでした。(終了コード: {1})</value>
+  </data>
+  <data name="MainForm_Msg_UserSettingsNotExportedMsgTitle" xml:space="preserve">
+    <value>設定のエクスポートに失敗しました</value>
+  </data>
+  <data name="MainForm_PluginsDataGrid_DuplicateSuffix" xml:space="preserve">
+    <value> (コピー)</value>
+  </data>
+  <data name="MainForm_PluginsDataGrid_IconToolTipText" xml:space="preserve">
+    <value>クリックして、このコマンドのアイコンファイルを選択します。
+Shift+クリックで、このコマンドにデフォルトのアイコンを使用させます。
+Ctrl+クリックで、このコマンドにアイコンを表示させません。</value>
+  </data>
+  <data name="MSYS_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>MSYS/MSYS2パスをコピー</value>
+  </data>
+  <data name="PipelineElement_ApplyPipelinePlugin" xml:space="preserve">
+    <value>ベースコマンドを使用</value>
+  </data>
+  <data name="PipelineElement_ApplyPipelinePlugin_HelpText" xml:space="preserve">
+    <value>パスの初期値を取得するためのベースコマンドを選択します</value>
+  </data>
+  <data name="PipelineElement_ApplyPlugin" xml:space="preserve">
+    <value>ベースコマンドを使用(カスタムコマンドは除く)</value>
+  </data>
+  <data name="PipelineElement_ApplyPlugin_HelpText" xml:space="preserve">
+    <value>パスの初期値を取得するためのベースコマンド(カスタムコマンドは除く)を選択します</value>
+  </data>
+  <data name="PipelineElement_BackToForwardSlashes" xml:space="preserve">
+    <value>バックスラッシュをスラッシュに変換</value>
+  </data>
+  <data name="PipelineElement_BackToForwardSlashes_HelpText" xml:space="preserve">
+    <value>パス内のすべてのバックスラッシュ( \ )をスラッシュ( / )に置き換えます</value>
+  </data>
+  <data name="PipelineElement_CommandLine" xml:space="preserve">
+    <value>オプション: コマンドラインを実行</value>
+  </data>
+  <data name="PipelineElement_CommandLine_HelpText" xml:space="preserve">
+    <value>パスをクリップボードにコピーする代わりに、コマンドライン(実行ファイルと引数)を起動し、パスを引数に直接またはリストファイル経由で含めます</value>
+  </data>
+  <data name="PipelineElement_CopyNPathParts" xml:space="preserve">
+    <value>#個のパス部分をコピー(最初または最後から)</value>
+  </data>
+  <data name="PipelineElement_CopyNPathParts_HelpText" xml:space="preserve">
+    <value>パスの最初または最後から、一定数の部分のみを保持します</value>
+  </data>
+  <data name="PipelineElement_DisplayForSelection" xml:space="preserve">
+    <value>オプション: 選択に応じた表示</value>
+  </data>
+  <data name="PipelineElement_DisplayForSelection_HelpText" xml:space="preserve">
+    <value>ファイルやフォルダが選択されているときにコマンドをメニューに表示するかを指定します。</value>
+  </data>
+  <data name="PipelineElement_DuplicateStackValue" xml:space="preserve">
+    <value>スタックの最上部の値を複製</value>
+  </data>
+  <data name="PipelineElement_DuplicateStackValue_HelpText" xml:space="preserve">
+    <value>スタックの最上部にある値を複製します</value>
+  </data>
+  <data name="PipelineElement_EmailLinks" xml:space="preserve">
+    <value>メールリンクを作成</value>
+  </data>
+  <data name="PipelineElement_EmailLinks_HelpText" xml:space="preserve">
+    <value>パスを&lt;と&gt;で囲んでメールリンクを作成します</value>
+  </data>
+  <data name="PipelineElement_EncodeURIChars" xml:space="preserve">
+    <value>URI文字をエンコード</value>
+  </data>
+  <data name="PipelineElement_EncodeURIChars_HelpText" xml:space="preserve">
+    <value>パス内のURI内で無効なすべての文字をパーセントエンコーディング(%xx)に置き換えます</value>
+  </data>
+  <data name="PipelineElement_EncodeURIWhitespace" xml:space="preserve">
+    <value>URIスペースをエンコード</value>
+  </data>
+  <data name="PipelineElement_EncodeURIWhitespace_HelpText" xml:space="preserve">
+    <value>パス内のすべてのスペース文字を%20に置き換えます</value>
+  </data>
+  <data name="PipelineElement_Executable" xml:space="preserve">
+    <value>オプション: 実行ファイルを起動</value>
+  </data>
+  <data name="PipelineElement_ExecutableWithFilelist" xml:space="preserve">
+    <value>オプション: リストファイルで実行ファイルを起動</value>
+  </data>
+  <data name="PipelineElement_ExecutableWithFilelist_HelpText" xml:space="preserve">
+    <value>パスをクリップボードにコピーする代わりに、リストファイルに保存し、そのリストファイルのパスを引数としてディスク上の実行ファイルを起動します</value>
+  </data>
+  <data name="PipelineElement_Executable_HelpText" xml:space="preserve">
+    <value>パスをクリップボードにコピーする代わりに、ディスク上の実行ファイルを起動してパスを引数として渡します</value>
+  </data>
+  <data name="PipelineElement_FindReplace" xml:space="preserve">
+    <value>検索 / 置換</value>
+  </data>
+  <data name="PipelineElement_FindReplace_HelpText" xml:space="preserve">
+    <value>パス内の指定された文字列のすべての出現を別の文字列に置き換えます</value>
+  </data>
+  <data name="PipelineElement_FollowSymlink" xml:space="preserve">
+    <value>シンボリックリンクをたどる</value>
+  </data>
+  <data name="PipelineElement_FollowSymlink_HelpText" xml:space="preserve">
+    <value>シンボリックリンクへのパスをそのターゲットのパスに置き換えます</value>
+  </data>
+  <data name="PipelineElement_ForwardToBackslashes" xml:space="preserve">
+    <value>スラッシュをバックスラッシュに変換</value>
+  </data>
+  <data name="PipelineElement_ForwardToBackslashes_HelpText" xml:space="preserve">
+    <value>パス内のすべてのスラッシュ( / )をバックスラッシュ( \ )に置き換えます</value>
+  </data>
+  <data name="PipelineElement_InjectDriveLabel" xml:space="preserve">
+    <value>ドライブラベルを挿入</value>
+  </data>
+  <data name="PipelineElement_InjectDriveLabel_HelpText" xml:space="preserve">
+    <value>パス内のすべての%DRIVELABEL%をドライブラベルに置き換えます</value>
+  </data>
+  <data name="PipelineElement_OptionalQuotes" xml:space="preserve">
+    <value>必要に応じて引用符を追加</value>
+  </data>
+  <data name="PipelineElement_OptionalQuotes_HelpText" xml:space="preserve">
+    <value>パスにスペースが含まれている場合、引用符(")で囲みます</value>
+  </data>
+  <data name="PipelineElement_PathsSeparator" xml:space="preserve">
+    <value>オプション: パス区切り文字</value>
+  </data>
+  <data name="PipelineElement_PathsSeparator_HelpText" xml:space="preserve">
+    <value>コピーされた複数のパスを区切るために使用する文字列を設定します。設定されていない場合は改行が使用されます</value>
+  </data>
+  <data name="PipelineElement_PopFromStack" xml:space="preserve">
+    <value>値をポップ</value>
+  </data>
+  <data name="PipelineElement_PopFromStack_HelpText" xml:space="preserve">
+    <value>スタックから値をポップし、場合によってはパスのどこかに挿入します</value>
+  </data>
+  <data name="PipelineElement_PushToStack" xml:space="preserve">
+    <value>値をプッシュ</value>
+  </data>
+  <data name="PipelineElement_PushToStack_HelpText" xml:space="preserve">
+    <value>スタックに値をプッシュします。場合によってはパスの一部です</value>
+  </data>
+  <data name="PipelineElement_Quotes" xml:space="preserve">
+    <value>引用符を追加</value>
+  </data>
+  <data name="PipelineElement_Quotes_HelpText" xml:space="preserve">
+    <value>パスを引用符(")で囲みます</value>
+  </data>
+  <data name="PipelineElement_RecursiveCopy" xml:space="preserve">
+    <value>オプション: パスの再帰的コピー</value>
+  </data>
+  <data name="PipelineElement_RecursiveCopy_HelpText" xml:space="preserve">
+    <value>パスをコピーする際に、サブフォルダを再帰的に探索します</value>
+  </data>
+  <data name="PipelineElement_Regex" xml:space="preserve">
+    <value>正規表現を使用して検索 / 置換</value>
+  </data>
+  <data name="PipelineElement_Regex_HelpText" xml:space="preserve">
+    <value>正規表現を使用してパスに対して検索/置換操作を実行します</value>
+  </data>
+  <data name="PipelineElement_RemoveExt" xml:space="preserve">
+    <value>ファイル拡張子を削除</value>
+  </data>
+  <data name="PipelineElement_RemoveExt_HelpText" xml:space="preserve">
+    <value>パスの末尾にあるファイル拡張子を削除します</value>
+  </data>
+  <data name="PipelineElement_SwapStackValues" xml:space="preserve">
+    <value>スタックの最上部の2つの値を交換</value>
+  </data>
+  <data name="PipelineElement_SwapStackValues_HelpText" xml:space="preserve">
+    <value>スタックから2つの値をポップし、逆順でプッシュし直します</value>
+  </data>
+  <data name="PipelineElement_UnexpandEnvStrings" xml:space="preserve">
+    <value>環境変数を挿入</value>
+  </data>
+  <data name="PipelineElement_UnexpandEnvStrings_HelpText" xml:space="preserve">
+    <value>可能な場合、パスの一部を環境変数への参照(%USERPROFILE%など)に置き換えます</value>
+  </data>
+  <data name="PipelinePluginForm_EmptyName" xml:space="preserve">
+    <value>カスタムコマンドの名前を選択してください。</value>
+  </data>
+  <data name="PipelinePluginForm_MsgTitle" xml:space="preserve">
+    <value>カスタムコマンド</value>
+  </data>
+  <data name="PipelinePluginForm_PipelineTooComplexForSimpleMode" xml:space="preserve">
+    <value>このコマンドはシンプルモードでは編集できないほど複雑になりました。モードを変更すると、一部の設定が失われます。本当にシンプルモードに変更しますか?</value>
+  </data>
+  <data name="PipelinePluginInfo_DescriptionWithRequiredVersion" xml:space="preserve">
+    <value>{0} (必要なバージョン: {1})</value>
+  </data>
+  <data name="Plugin_PreviewError" xml:space="preserve">
+    <value>#エラー#</value>
+  </data>
+  <data name="REMOVE_PIPELINE_PLUGIN_MESSAGE" xml:space="preserve">
+    <value>コマンド"{0}"を削除してもよろしいですか?</value>
+  </data>
+  <data name="REMOVE_PIPELINE_PLUGIN_TITLE" xml:space="preserve">
+    <value>カスタムコマンドを削除</value>
+  </data>
+  <data name="SAMBA_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>Sambaパスをコピー</value>
+  </data>
+  <data name="SHORT_FOLDER_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>親フォルダの短いパスをコピー</value>
+  </data>
+  <data name="SHORT_NAME_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>短い名前をコピー</value>
+  </data>
+  <data name="SHORT_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>短いパスをコピー</value>
+  </data>
+  <data name="SHORT_UNC_FOLDER_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>親フォルダの短いUNCパスをコピー</value>
+  </data>
+  <data name="SHORT_UNC_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>短いUNCパスをコピー</value>
+  </data>
+  <data name="UNIX_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>Unixパスをコピー</value>
+  </data>
+  <data name="WSL_PATH_PLUGIN_DESCRIPTION" xml:space="preserve">
+    <value>WSLパスをコピー</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/Properties/Resources.resx
+++ b/PathCopyCopySettings/Properties/Resources.resx
@@ -489,6 +489,12 @@ Control-click to avoid displaying an icon for this command.</value>
   <data name="Language_French_DisplayName" xml:space="preserve">
     <value>French</value>
   </data>
+  <data name="Language_Japanese_DisplayName" xml:space="preserve">
+    <value>Japanese</value>
+  </data>
+  <data name="Language_Japanese_Name" xml:space="preserve">
+    <value>ja-JP</value>
+  </data>
   <data name="Language_French_Name" xml:space="preserve">
     <value>fr-CA</value>
   </data>

--- a/PathCopyCopySettings/UI/Forms/AdvancedPipelinePluginForm.ja-JP.resx
+++ b/PathCopyCopySettings/UI/Forms/AdvancedPipelinePluginForm.ja-JP.resx
@@ -1,0 +1,233 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CancelBtn.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンドを保存せずにウィンドウを閉じます</value>
+  </data>
+  <data name="OKBtn.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンドを保存してウィンドウを閉じます</value>
+  </data>
+  <data name="SwitchBtn.Text" xml:space="preserve">
+    <value>シンプルモード</value>
+  </data>
+  <data name="SwitchBtn.ToolTip" xml:space="preserve">
+    <value>シンプルモードに切り替えます。使いやすくなりますが、高度なオプションは少なくなります</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="NameTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>50, 12</value>
+  </data>
+  <data name="NameTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>576, 20</value>
+  </data>
+  <data name="NameTxt.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンドの名前</value>
+  </data>
+  <data name="ElementsLst.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンド内の要素のリスト</value>
+  </data>
+  <data name="ElementsImageList.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAABs
+        CgAAAk1TRnQBSQFMAgEBBAEAAWgBAAFoAQABEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ADQAE9AwA
+        BPQsAAH0AhQB9AwAAfQCFAH0LAAB9AIUAfQMAAH0AhQB9CwAAfQCFAH0DAAB9AIUAfQIAAH/BgAB/wsA
+        Av8OAAH/AfQCFAH0Af8KAAH/AfMCFAHzAf8GAAH/AvQEAAL0Af8JAAH/AvQB/wwAAf8B9AHsAhQB7AH0
+        Af8IAAH/AfQB7AIUAewB9AH/BAAB/wH0Ae8B8QH0AgAB9AHxAe8B9AH/BwAB/wH0AgcB9AH/CAAE9AHv
+        BBQB9wH0CAAB9AHvBBQB9wH0BAAB9AHyARMBEgHxAvQB8QESARMB8gH0BgAB/wH0AQcCEwEHAfQB/wcA
+        A/QB8AYUAbwB9AIAAv8CAAH0AfAGFAG8AfQDAAH/AfQBBwETARIC8QESARMBBwH0Af8FAAH/AfQBBwET
+        AhIBEwEHAfQB/wQAA/QBTAP0BRQBEwHyAfQB/wLzAf8B9AHzAQcGFAETAfEB9AMAAf8B9AEHARMCEgET
+        AQcB9AH/BQAB/wH0AQcBEwESAvEBEgETAQcB9AH/AwAB9AFMAfQBTAH0AUwB9AYUAW0C8wJGAvMBRgFv
+        Ae8GFAFtAfQEAAH/AfQBBwITAQcB9AH/BgAB9AHyARMBEgHxAvQB8QESARMB8gH0AgAD9ANMCvQB8wFG
+        ASQCRgEkAW8J9AUAAf8B9AIHAfQB/wcAAf8B9AHvAfEB9AIAAfQB8QHvAfQB/wIAAfQDTAH0A0wB9AcA
+        Af8B8wFGAiQBbwH0Af8OAAH/AvQB/wkAAf8C9AQAAvQB/wMAAvQBGgNMARoC9AcAAfQB8wFGAiQBRgHz
+        Af8PAAL/CwAB/wYAAf8FAAH0AUwB9AFMAfQBTAH0CAAB8wFGASQBbwFGASQBRgH0Af8oAAP0AUwD9AgA
+        AfQCbwH0AfMBRgFvAfQB/yoAA/QKAAH/AvQC/wL0Af8oAAFCAU0BPgcAAT4DAAEoAwABQAMAASADAAEB
+        AQABAQYAAQEWAAP/gQAB/wEPAf8BDwX/AQ8B/wEPBf8BDwH/AQ8F/wEPAf8BDwH3Ae8B/gF/Af4BBwH+
+        AQcB4wHHAfwBPwH8AQMB/AEDAcEBgwH4AR8B4AEDAfwBAwHAAQMB8AEPAeABAQGYAQEBwAEDAeABBwGA
+        AwAB4AEHAcABAwGAAwAB8AEPAcABAwQAAfgBHwHBAYMBAAF/AQAB/wH8AT8B4wHHAQABfwEAAf8B/gF/
+        AfcB7wGAAf8BAAF/BP8BgAH/AQABfwT/AeMB/wEABf8L
+</value>
+  </data>
+  <data name="NewElementBtn.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンドに新しい要素を追加します</value>
+  </data>
+  <data name="DeleteElementBtn.ToolTip" xml:space="preserve">
+    <value>選択した要素をこのカスタムコマンドから削除します</value>
+  </data>
+  <data name="MoveElementUpBtn.ToolTip" xml:space="preserve">
+    <value>選択した要素を1つ上に移動します</value>
+  </data>
+  <data name="MoveElementDownBtn.ToolTip" xml:space="preserve">
+    <value>選択した要素を1つ下に移動します</value>
+  </data>
+  <data name="NameLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 13</value>
+  </data>
+  <data name="NameLbl.Text" xml:space="preserve">
+    <value>名前(&N):</value>
+  </data>
+  <data name="ElementsLbl.Text" xml:space="preserve">
+    <value>要素(&E):</value>
+  </data>
+  <data name="SelectElementLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>305, 13</value>
+  </data>
+  <data name="SelectElementLbl.Text" xml:space="preserve">
+    <value>リストから要素を選択してプロパティを編集してください。</value>
+  </data>
+  <data name="MinVersionLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>342, 13</value>
+  </data>
+  <data name="MinVersionLbl.Text" xml:space="preserve">
+    <value>このコマンドに必要なPath Copy Copyの最小バージョン: {0}</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>カスタムコマンド (エキスパートモード)</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/Forms/ImportPipelinePluginsForm.ja-JP.resx
+++ b/PathCopyCopySettings/UI/Forms/ImportPipelinePluginsForm.ja-JP.resx
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ChoosePipelinePluginsLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 13</value>
+  </data>
+  <data name="ChoosePipelinePluginsLbl.Text" xml:space="preserve">
+    <value>インポートするカスタムコマンドを選択してください:</value>
+  </data>
+  <data name="PipelinePluginsLst.ToolTip" xml:space="preserve">
+    <value>インポートするカスタムコマンド</value>
+  </data>
+  <data name="OKBtn.ToolTip" xml:space="preserve">
+    <value>選択したカスタムコマンドをインポートしてウィンドウを閉じます</value>
+  </data>
+  <data name="CancelBtn.Text" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="CancelBtn.ToolTip" xml:space="preserve">
+    <value>カスタムコマンドのインポートをキャンセルしてウィンドウを閉じます</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>カスタムコマンドの選択</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/Forms/MainForm.ja-JP.resx
+++ b/PathCopyCopySettings/UI/Forms/MainForm.ja-JP.resx
@@ -1,0 +1,518 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ApplyBtn.Text" xml:space="preserve">
+    <value>適用(&A)</value>
+  </data>
+  <data name="ApplyBtn.ToolTip" xml:space="preserve">
+    <value>これまでの変更を保存しますが、ウィンドウは開いたままにします</value>
+  </data>
+  <data name="OKBtn.ToolTip" xml:space="preserve">
+    <value>設定の変更を保存してウィンドウを閉じます</value>
+  </data>
+  <data name="CancelBtn.Text" xml:space="preserve">
+    <value>キャンセル(&N)</value>
+  </data>
+  <data name="CancelBtn.ToolTip" xml:space="preserve">
+    <value>これまでの変更をキャンセルしてウィンドウを閉じます</value>
+  </data>
+  <data name="DuplicatePipelinePluginBtn.Text" xml:space="preserve">
+    <value>複製(&L)</value>
+  </data>
+  <data name="DuplicatePipelinePluginBtn.ToolTip" xml:space="preserve">
+    <value>選択したカスタムコマンドのコピーを作成します</value>
+  </data>
+  <data name="PreviewCtrl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="AddSeparatorBtn.Text" xml:space="preserve">
+    <value>区切り線(&S)</value>
+  </data>
+  <data name="AddSeparatorBtn.ToolTip" xml:space="preserve">
+    <value>選択したコマンドの後に区切り線を挿入します</value>
+  </data>
+  <data name="ImportPipelinePluginsBtn.Text" xml:space="preserve">
+    <value>インポート(&I)...</value>
+  </data>
+  <data name="ImportPipelinePluginsBtn.ToolTip" xml:space="preserve">
+    <value>ディスク上のファイルからカスタムコマンドをインポートします</value>
+  </data>
+  <data name="ExportPipelinePluginsBtn.Text" xml:space="preserve">
+    <value>エクスポート(&P)...</value>
+  </data>
+  <data name="ExportPipelinePluginsBtn.ToolTip" xml:space="preserve">
+    <value>選択したカスタムコマンドをディスク上のファイルにエクスポートします</value>
+  </data>
+  <data name="BevelLineLbl2.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RemovePluginBtn.Text" xml:space="preserve">
+    <value>削除(&F)</value>
+  </data>
+  <data name="RemovePluginBtn.ToolTip" xml:space="preserve">
+    <value>選択したカスタムコマンドまたは区切り線を削除します</value>
+  </data>
+  <data name="EditPipelinePluginBtn.Text" xml:space="preserve">
+    <value>編集(&E)...</value>
+  </data>
+  <data name="EditPipelinePluginBtn.ToolTip" xml:space="preserve">
+    <value>選択したカスタムコマンドを変更します</value>
+  </data>
+  <data name="AddPipelinePluginBtn.Text" xml:space="preserve">
+    <value>新規(&V)...</value>
+  </data>
+  <data name="AddPipelinePluginBtn.ToolTip" xml:space="preserve">
+    <value>新しいカスタムコマンドを作成します</value>
+  </data>
+  <data name="BevelLineLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="MovePluginDownBtn.Text" xml:space="preserve">
+    <value>下へ(&D)</value>
+  </data>
+  <data name="MovePluginDownBtn.ToolTip" xml:space="preserve">
+    <value>選択したコマンドを1つ下に移動します</value>
+  </data>
+  <data name="MovePluginUpBtn.Text" xml:space="preserve">
+    <value>上へ(&M)</value>
+  </data>
+  <data name="MovePluginUpBtn.ToolTip" xml:space="preserve">
+    <value>選択したコマンドを1つ上に移動します</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="PluginsExplanationLbl2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>421, 13</value>
+  </data>
+  <data name="PluginsExplanationLbl2.Text" xml:space="preserve">
+    <value>サブメニューに表示するか、またコマンドを追加、削除、並び替えすることができます。</value>
+  </data>
+  <data name="PluginsExplanationLbl2.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="IconCol.HeaderText" xml:space="preserve">
+    <value>アイコン</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="IconCol.Width" type="System.Int32, mscorlib">
+    <value>40</value>
+  </data>
+  <data name="PluginCol.HeaderText" xml:space="preserve">
+    <value>コマンド</value>
+  </data>
+  <data name="InMainMenuCol.HeaderText" xml:space="preserve">
+    <value>メニュー</value>
+  </data>
+  <data name="InMainMenuCol.Width" type="System.Int32, mscorlib">
+    <value>40</value>
+  </data>
+  <data name="InSubmenuCol.HeaderText" xml:space="preserve">
+    <value>サブメニュー</value>
+  </data>
+  <data name="InSubmenuCol.Width" type="System.Int32, mscorlib">
+    <value>66</value>
+  </data>
+  <data name="PluginsDataGrid.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PluginsExplanationLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>450, 13</value>
+  </data>
+  <data name="PluginsExplanationLbl.Text" xml:space="preserve">
+    <value>ここでは、エクスプローラーのコンテキストメニューに表示するコマンドを選択できます</value>
+  </data>
+  <data name="PluginsExplanationLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PluginsPage.Text" xml:space="preserve">
+    <value>コマンド</value>
+  </data>
+  <data name="PluginsPage.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RecursiveCopyChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 17</value>
+  </data>
+  <data name="RecursiveCopyChk.Text" xml:space="preserve">
+    <value>パスを再帰的にコピー(&M)</value>
+  </data>
+  <data name="RecursiveCopyChk.ToolTip" xml:space="preserve">
+    <value>パスをコピーする際に、サブフォルダを再帰的に探索します</value>
+  </data>
+  <data name="LanguageCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>58, 492</value>
+  </data>
+  <data name="LanguageCombo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>366, 21</value>
+  </data>
+  <data name="LanguageCombo.ToolTip" xml:space="preserve">
+    <value>アプリケーションの言語</value>
+  </data>
+  <data name="LanguageLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 13</value>
+  </data>
+  <data name="LanguageLbl.Text" xml:space="preserve">
+    <value>言語(&G):</value>
+  </data>
+  <data name="LanguageLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TrueLnkPathsChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>319, 17</value>
+  </data>
+  <data name="TrueLnkPathsChk.Text" xml:space="preserve">
+    <value>ショートカットファイル(.lnk)自体のパスをコピー(&K)</value>
+  </data>
+  <data name="TrueLnkPathsChk.ToolTip" xml:space="preserve">
+    <value>ショートカットファイル(.lnk)のパスをコピーする際、ターゲットへのパスではなく、ショートカットファイル自体のパスをコピーします</value>
+  </data>
+  <data name="UsePreviewModeInMainMenuChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>185, 17</value>
+  </data>
+  <data name="UsePreviewModeInMainMenuChk.Text" xml:space="preserve">
+    <value>...メインメニューでも表示(&C)</value>
+  </data>
+  <data name="UsePreviewModeInMainMenuChk.ToolTip" xml:space="preserve">
+    <value>メインのコンテキストメニューでもコマンドのプレビューを表示します</value>
+  </data>
+  <data name="AppendSepForDirChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 17</value>
+  </data>
+  <data name="AppendSepForDirChk.Text" xml:space="preserve">
+    <value>ディレクトリパスに区切り文字を追加(&R)</value>
+  </data>
+  <data name="AppendSepForDirChk.ToolTip" xml:space="preserve">
+    <value>コピーしたパスがディレクトリを指している場合、パスの末尾に区切り文字(例: \または/)を追加します</value>
+  </data>
+  <data name="UseFQDNChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>353, 17</value>
+  </data>
+  <data name="UseFQDNChk.Text" xml:space="preserve">
+    <value>UNCパスをコピーする際に完全修飾ドメイン名を使用(&D)</value>
+  </data>
+  <data name="UseFQDNChk.ToolTip" xml:space="preserve">
+    <value>UNCパスをコピーする際に完全修飾ドメイン名(FQDN)を使用します</value>
+  </data>
+  <data name="AreQuotesOptionalChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 17</value>
+  </data>
+  <data name="AreQuotesOptionalChk.Text" xml:space="preserve">
+    <value>...スペースが含まれている場合のみ(&S)</value>
+  </data>
+  <data name="AreQuotesOptionalChk.ToolTip" xml:space="preserve">
+    <value>パスにスペースが含まれている場合にのみ引用符で囲むかを指定します</value>
+  </data>
+  <data name="CtrlKeyPluginCombo.ToolTip" xml:space="preserve">
+    <value>エクスプローラーのコンテキストメニューを開く際にCtrlキーが押されている場合に自動的に使用するコマンド</value>
+  </data>
+  <data name="CtrlKeyPluginChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>419, 17</value>
+  </data>
+  <data name="CtrlKeyPluginChk.Text" xml:space="preserve">
+    <value>メニューを開く際にCtrlキーが押されている場合、次のコマンドを使用(&F)</value>
+  </data>
+  <data name="CtrlKeyPluginChk.ToolTip" xml:space="preserve">
+    <value>Ctrlキーが押されている状態でエクスプローラーのコンテキストメニューを開いたときに自動的に使用するコマンドを選択します</value>
+  </data>
+  <data name="EncodeURICharsChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>320, 17</value>
+  </data>
+  <data name="EncodeURICharsChk.Text" xml:space="preserve">
+    <value>...およびURI内の無効な文字をすべてエンコード(例: %xx)(&V)</value>
+  </data>
+  <data name="EncodeURICharsChk.ToolTip" xml:space="preserve">
+    <value>パス内のURI内で無効なすべての文字をパーセントエンコーディング(%xx)に置き換えます</value>
+  </data>
+  <data name="EncodeURIWhitespaceChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>344, 17</value>
+  </data>
+  <data name="EncodeURIWhitespaceChk.Text" xml:space="preserve">
+    <value>スペースをパーセントエンコーディングでエンコード(例: %20)(&P)</value>
+  </data>
+  <data name="EncodeURIWhitespaceChk.ToolTip" xml:space="preserve">
+    <value>パス内のすべてのスペースを%20に置き換えます</value>
+  </data>
+  <data name="CopyOnSameLineChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>221, 17</value>
+  </data>
+  <data name="CopyOnSameLineChk.Text" xml:space="preserve">
+    <value>すべてのパスを同じ行にコピー(&L)</value>
+  </data>
+  <data name="CopyOnSameLineChk.ToolTip" xml:space="preserve">
+    <value>複数のパスをコピーする際、別々の行(改行で区切る)ではなく、同じ行(スペースで区切る)にすべてコピーします</value>
+  </data>
+  <data name="DropRedundantWordsChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>443, 17</value>
+  </data>
+  <data name="DropRedundantWordsChk.Text" xml:space="preserve">
+    <value>サブメニューで「コピー」や「長い/短い」などの冗長な語を表示しない(&O)</value>
+  </data>
+  <data name="DropRedundantWordsChk.ToolTip" xml:space="preserve">
+    <value>サブメニューでコマンドを表示する際、冗長な語を省略します</value>
+  </data>
+  <data name="UsePreviewModeChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>408, 17</value>
+  </data>
+  <data name="UsePreviewModeChk.Text" xml:space="preserve">
+    <value>サブメニューでコマンドの説明の代わりにプレビューを表示(&U)</value>
+  </data>
+  <data name="UsePreviewModeChk.ToolTip" xml:space="preserve">
+    <value>サブメニューで、コマンドを通常通り表示する代わりに、そのコマンドを選択した場合にコピーされるパスのプレビューを表示します</value>
+  </data>
+  <data name="UseIconForSubmenuChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>208, 17</value>
+  </data>
+  <data name="UseIconForSubmenuChk.Text" xml:space="preserve">
+    <value>サブメニューの横にアイコンを表示(&I)</value>
+  </data>
+  <data name="UseIconForSubmenuChk.ToolTip" xml:space="preserve">
+    <value>エクスプローラーのコンテキストメニューでサブメニューの横にPath Copy Copyのアイコンを表示します</value>
+  </data>
+  <data name="EmailLinksChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>346, 17</value>
+  </data>
+  <data name="EmailLinksChk.Text" xml:space="preserve">
+    <value>コピーしたパスを&lt;と&gt;で囲む(メールリンクを作成)(&E)</value>
+  </data>
+  <data name="EmailLinksChk.ToolTip" xml:space="preserve">
+    <value>コピーしたすべてのパスを&lt;と&gt;で囲みます(これによりメールリンクが作成されます)</value>
+  </data>
+  <data name="EnableSoftwareUpdateChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>216, 17</value>
+  </data>
+  <data name="EnableSoftwareUpdateChk.Text" xml:space="preserve">
+    <value>アップデートを自動的に確認(&J)</value>
+  </data>
+  <data name="EnableSoftwareUpdateChk.ToolTip" xml:space="preserve">
+    <value>Path Copy Copyの新しいバージョンが存在するかを自動的に確認し、存在する場合はインストールを提案します</value>
+  </data>
+  <data name="AlwaysShowSubmenuChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 17</value>
+  </data>
+  <data name="AlwaysShowSubmenuChk.Text" xml:space="preserve">
+    <value>常にサブメニューを表示(&T)</value>
+  </data>
+  <data name="AlwaysShowSubmenuChk.ToolTip" xml:space="preserve">
+    <value>エクスプローラーのコンテキストメニューにPath Copy Copyのサブメニューを常に表示します(それ以外の場合は、Shiftキーを押したまま表示する必要があります)</value>
+  </data>
+  <data name="HiddenSharesChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>295, 17</value>
+  </data>
+  <data name="HiddenSharesChk.Text" xml:space="preserve">
+    <value>UNCパスをコピーする際に隠し共有を使用(&H)</value>
+  </data>
+  <data name="HiddenSharesChk.ToolTip" xml:space="preserve">
+    <value>UNCパスをコピーする際に隠し共有($で終わるもので、\\server\C$のような管理共有を含む)を使用します</value>
+  </data>
+  <data name="AddQuotesChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 17</value>
+  </data>
+  <data name="AddQuotesChk.Text" xml:space="preserve">
+    <value>コピーしたパスを引用符で囲む(&G)</value>
+  </data>
+  <data name="AddQuotesChk.ToolTip" xml:space="preserve">
+    <value>コピーしたすべてのパスを引用符(")で囲みます</value>
+  </data>
+  <data name="MiscOptionsPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>465, 522</value>
+  </data>
+  <data name="MiscOptionsPage.Text" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="MiscOptionsPage.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ProductAndVersionLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CopyrightLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="VisitWebsiteLbl.Text" xml:space="preserve">
+    <value>ウェブサイトをご覧ください:</value>
+  </data>
+  <data name="VisitWebsiteLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SiteLinkLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="LicenseExplanationLbl.Text" xml:space="preserve">
+    <value>Path Copy CopyはMIT Licenseの下で配布されている
+フリーソフトウェアです。詳細については次を参照してください</value>
+  </data>
+  <data name="LicenseExplanationLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="LicenseTxtLinkLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="DonationLinkLbl.LinkArea" type="System.Windows.Forms.LinkArea, System.Windows.Forms">
+    <value>46, 10</value>
+  </data>
+  <data name="DonationLinkLbl.Text" xml:space="preserve">
+    <value>Path Copy Copyを気に入っていただけた場合は、PayPal経由でご寄付をお願いします!
+寄付は開発の資金援助とサポートの提供に役立ちます。</value>
+  </data>
+  <data name="DonationLinkLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="AboutTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>459, 516</value>
+  </data>
+  <data name="AboutTableLayoutPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="AboutPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>465, 522</value>
+  </data>
+  <data name="AboutPage.Text" xml:space="preserve">
+    <value>バージョン情報</value>
+  </data>
+  <data name="AboutPage.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="MainTabCtrl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ExportPipelinePluginsSaveDlg.Filter" xml:space="preserve">
+    <value>エクスポートされたカスタムコマンド (*.eccv3)|*.eccv3|エクスポートされたカスタムコマンド (17.1以前) (*.ecc)|*.ecc|エクスポートされたカスタムコマンド (12.0以前) (*.pccpp)|*.pccpp</value>
+  </data>
+  <data name="ImportPipelinePluginsOpenDlg.Filter" xml:space="preserve">
+    <value>エクスポートされたカスタムコマンド (*.eccv3;*.ecc;*.pccpp)|*.eccv3;*.ecc;*.pccpp</value>
+  </data>
+  <data name="ChoosePluginIconOpenDlg.Filter" xml:space="preserve">
+    <value>画像ファイル (*.bmp;*.jpg;*.gif;*.png;*.ico)|*.bmp;*.jpg;*.gif;*.png;*.ico|すべてのファイル (*.*)|*.*</value>
+  </data>
+  <data name="ExportUserSettingsSaveDlg.Filter" xml:space="preserve">
+    <value>エクスポートされた設定 (*.reg)|*.reg</value>
+  </data>
+  <data name="ExportUserSettingsBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 23</value>
+  </data>
+  <data name="ExportUserSettingsBtn.Text" xml:space="preserve">
+    <value>設定をエクスポート(&X)...</value>
+  </data>
+  <data name="ExportUserSettingsBtn.ToolTip" xml:space="preserve">
+    <value>設定をディスク上のファイルにエクスポートします</value>
+  </data>
+  <data name="$this.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/Forms/PipelinePluginForm.ja-JP.resx
+++ b/PathCopyCopySettings/UI/Forms/PipelinePluginForm.ja-JP.resx
@@ -1,0 +1,434 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="NameLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 13</value>
+  </data>
+  <data name="NameLbl.Text" xml:space="preserve">
+    <value>名前(&N):</value>
+  </data>
+  <data name="NameLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="NameTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>50, 12</value>
+  </data>
+  <data name="NameTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 20</value>
+  </data>
+  <data name="NameTxt.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンドの名前</value>
+  </data>
+  <data name="BasePluginLst.ToolTip" xml:space="preserve">
+    <value>パスをコピーするために使用するベースコマンド。追加オプションは後で適用されます</value>
+  </data>
+  <data name="BaseCommandLbl2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>449, 13</value>
+  </data>
+  <data name="BaseCommandLbl2.Text" xml:space="preserve">
+    <value>これは、追加オプションを適用する前にコピーするパスのタイプを決定します。</value>
+  </data>
+  <data name="BaseCommandLbl2.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="BaseCommandLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>370, 13</value>
+  </data>
+  <data name="BaseCommandLbl.Text" xml:space="preserve">
+    <value>カスタムコマンドのベースコマンドを選択してください。</value>
+  </data>
+  <data name="BaseCommandLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="BasePluginPage.Text" xml:space="preserve">
+    <value>ベースコマンド</value>
+  </data>
+  <data name="BasePluginPage.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RecursiveCopyChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 17</value>
+  </data>
+  <data name="RecursiveCopyChk.Text" xml:space="preserve">
+    <value>パスを再帰的にコピー(&N)</value>
+  </data>
+  <data name="RecursiveCopyChk.ToolTip" xml:space="preserve">
+    <value>パスをコピーする際に、サブフォルダを再帰的に探索します</value>
+  </data>
+  <data name="WithFilelistChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>336, 17</value>
+  </data>
+  <data name="WithFilelistChk.Text" xml:space="preserve">
+    <value>...パスを直接渡す代わりにファイルを使用(&D)</value>
+  </data>
+  <data name="WithFilelistChk.ToolTip" xml:space="preserve">
+    <value>パスを実行ファイルに引数として直接渡す代わりに、ディスク上のファイルに保存して、そのファイルのパスを実行ファイルに渡します</value>
+  </data>
+  <data name="BrowserForExecutableBtn.Text" xml:space="preserve">
+    <value>参照...</value>
+  </data>
+  <data name="BrowserForExecutableBtn.ToolTip" xml:space="preserve">
+    <value>起動する実行ファイルを選択するダイアログを開きます</value>
+  </data>
+  <data name="ExecutableTxt.ToolTip" xml:space="preserve">
+    <value>起動する実行ファイル</value>
+  </data>
+  <data name="ExecutableLbl.Text" xml:space="preserve">
+    <value>実行ファイル(&X):</value>
+  </data>
+  <data name="ExecutableLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="LaunchExecutableChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>313, 17</value>
+  </data>
+  <data name="LaunchExecutableChk.Text" xml:space="preserve">
+    <value>クリップボードにコピーする代わりに実行ファイルを起動(&C)
+</value>
+  </data>
+  <data name="LaunchExecutableChk.ToolTip" xml:space="preserve">
+    <value>パスをクリップボードにコピーする代わりに、ディスク上の実行ファイルを起動してパスを引数として渡します</value>
+  </data>
+  <data name="CopyOnSameLineChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>255, 17</value>
+  </data>
+  <data name="CopyOnSameLineChk.Text" xml:space="preserve">
+    <value>複数のパスを同じ行にコピー(&L)</value>
+  </data>
+  <data name="CopyOnSameLineChk.ToolTip" xml:space="preserve">
+    <value>複数のファイル/フォルダが選択されている場合、パスを別々の行(改行で区切る)ではなく、同じ行(スペースで区切る)にコピーします</value>
+  </data>
+  <data name="OptionsGroupBox.Text" xml:space="preserve">
+    <value>その他</value>
+  </data>
+  <data name="OptionsGroupBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="UnexpandEnvStringsChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>328, 17</value>
+  </data>
+  <data name="UnexpandEnvStringsChk.Text" xml:space="preserve">
+    <value>可能な場合はパスに環境変数を使用(&M)</value>
+  </data>
+  <data name="UnexpandEnvStringsChk.ToolTip" xml:space="preserve">
+    <value>%USERPROFILE%などの環境変数の値に対応するパスの部分を、これらの変数への参照に置き換えるかを指定します</value>
+  </data>
+  <data name="TestRegexBtn.Location" type="System.Drawing.Point, System.Drawing">
+    <value>301, 71</value>
+  </data>
+  <data name="TestRegexBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 23</value>
+  </data>
+  <data name="TestRegexBtn.Text" xml:space="preserve">
+    <value>テスト(&T)...</value>
+  </data>
+  <data name="TestRegexBtn.ToolTip" xml:space="preserve">
+    <value>現在使用されている正規表現と置換式をテストするウィンドウを開きます</value>
+  </data>
+  <data name="IgnoreCaseChk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>194, 75</value>
+  </data>
+  <data name="IgnoreCaseChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 17</value>
+  </data>
+  <data name="IgnoreCaseChk.Text" xml:space="preserve">
+    <value>大文字小文字を区別しない(&A)</value>
+  </data>
+  <data name="IgnoreCaseChk.ToolTip" xml:space="preserve">
+    <value>正規表現を使用して検索/置換を行う際に、大文字小文字を区別するかを指定します</value>
+  </data>
+  <data name="UseRegexChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 17</value>
+  </data>
+  <data name="UseRegexChk.Text" xml:space="preserve">
+    <value>正規表現を使用(&U)</value>
+  </data>
+  <data name="UseRegexChk.ToolTip" xml:space="preserve">
+    <value>検索/置換操作に正規表現を使用するかを指定します</value>
+  </data>
+  <data name="ReplaceTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>91, 45</value>
+  </data>
+  <data name="ReplaceTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>265, 20</value>
+  </data>
+  <data name="ReplaceTxt.ToolTip" xml:space="preserve">
+    <value>パス内で見つかった要素を置き換えるために使用する文字列。正規表現を使用する場合は、これは置換式です</value>
+  </data>
+  <data name="ReplaceLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 13</value>
+  </data>
+  <data name="ReplaceLbl.Text" xml:space="preserve">
+    <value>置換(&R):</value>
+  </data>
+  <data name="ReplaceLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="FindTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>65, 19</value>
+  </data>
+  <data name="FindTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>291, 20</value>
+  </data>
+  <data name="FindTxt.ToolTip" xml:space="preserve">
+    <value>パス内で検索する文字列。正規表現を使用する場合は、これは正規表現です</value>
+  </data>
+  <data name="FindLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 13</value>
+  </data>
+  <data name="FindLbl.Text" xml:space="preserve">
+    <value>検索(&H):</value>
+  </data>
+  <data name="FindLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="FindReplaceGroupBox.Text" xml:space="preserve">
+    <value>検索 / 置換</value>
+  </data>
+  <data name="FindReplaceGroupBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="NoSlashesChangeRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 17</value>
+  </data>
+  <data name="NoSlashesChangeRadio.Text" xml:space="preserve">
+    <value>スラッシュを変更しない(&B)</value>
+  </data>
+  <data name="NoSlashesChangeRadio.ToolTip" xml:space="preserve">
+    <value>パス内のスラッシュを変更しません</value>
+  </data>
+  <data name="BackToForwardSlashesRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>318, 17</value>
+  </data>
+  <data name="BackToForwardSlashesRadio.Text" xml:space="preserve">
+    <value>すべてのバックスラッシュをスラッシュに変更(&O)</value>
+  </data>
+  <data name="BackToForwardSlashesRadio.ToolTip" xml:space="preserve">
+    <value>パス内のすべてのバックスラッシュ( \ )をスラッシュ( / )に置き換えます</value>
+  </data>
+  <data name="ForwardToBackslashesRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>358, 17</value>
+  </data>
+  <data name="ForwardToBackslashesRadio.Text" xml:space="preserve">
+    <value>すべてのスラッシュ( / )をバックスラッシュ( \ )に変更(&I)</value>
+  </data>
+  <data name="ForwardToBackslashesRadio.ToolTip" xml:space="preserve">
+    <value>パス内のすべてのスラッシュ( / )をバックスラッシュ( \ )に置き換えます</value>
+  </data>
+  <data name="SlashesGroupBox.Text" xml:space="preserve">
+    <value>スラッシュ</value>
+  </data>
+  <data name="SlashesGroupBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RemoveExtChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 17</value>
+  </data>
+  <data name="RemoveExtChk.Text" xml:space="preserve">
+    <value>ファイル拡張子を削除(&F)</value>
+  </data>
+  <data name="RemoveExtChk.ToolTip" xml:space="preserve">
+    <value>パスの末尾にあるファイル拡張子を削除します</value>
+  </data>
+  <data name="OptionalQuotesChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 17</value>
+  </data>
+  <data name="OptionalQuotesChk.Text" xml:space="preserve">
+    <value>...スペースが含まれている場合のみ(&S)</value>
+  </data>
+  <data name="OptionalQuotesChk.ToolTip" xml:space="preserve">
+    <value>パスにスペースが含まれている場合にのみ引用符で囲むかを指定します</value>
+  </data>
+  <data name="EncodeURICharsChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>320, 17</value>
+  </data>
+  <data name="EncodeURICharsChk.Text" xml:space="preserve">
+    <value>...およびURI内の無効な文字をすべてエンコード(例: %xx)(&V)</value>
+  </data>
+  <data name="EncodeURICharsChk.ToolTip" xml:space="preserve">
+    <value>パス内のURI内で無効なすべての文字をパーセントエンコーディング( %xx )に置き換えます</value>
+  </data>
+  <data name="EncodeURIWhitespaceChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>344, 17</value>
+  </data>
+  <data name="EncodeURIWhitespaceChk.Text" xml:space="preserve">
+    <value>スペースをパーセントエンコーディングでエンコード(例: %20)(&P)</value>
+  </data>
+  <data name="EncodeURIWhitespaceChk.ToolTip" xml:space="preserve">
+    <value>パス内のすべてのスペースを%20に置き換えます</value>
+  </data>
+  <data name="EmailLinksChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>287, 17</value>
+  </data>
+  <data name="EmailLinksChk.Text" xml:space="preserve">
+    <value>パスを&lt;と&gt;で囲む(メールリンクを作成)(&E)</value>
+  </data>
+  <data name="EmailLinksChk.ToolTip" xml:space="preserve">
+    <value>パスを&lt;と&gt;で囲みます(これによりメールリンクが作成されます)</value>
+  </data>
+  <data name="QuotesChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 17</value>
+  </data>
+  <data name="QuotesChk.Text" xml:space="preserve">
+    <value>パスを引用符で囲む(&G)</value>
+  </data>
+  <data name="QuotesChk.ToolTip" xml:space="preserve">
+    <value>パスを引用符( " )で囲みます</value>
+  </data>
+  <data name="DecorationsGroupBox.Text" xml:space="preserve">
+    <value>装飾</value>
+  </data>
+  <data name="DecorationsGroupBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="OptionsPage.Text" xml:space="preserve">
+    <value>追加オプション</value>
+  </data>
+  <data name="OptionsPage.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="MainTabControl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="OKBtn.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンドを保存してウィンドウを閉じます</value>
+  </data>
+  <data name="CancelBtn.ToolTip" xml:space="preserve">
+    <value>このカスタムコマンドを保存せずにウィンドウを閉じます</value>
+  </data>
+  <data name="ChooseExecutableOpenDlg.Filter" xml:space="preserve">
+    <value>実行ファイル (*.exe;*.com;*.bat;*.cmd)|*.exe;*.com;*.bat;*.cmd|すべてのファイル (*.*)|*.*</value>
+  </data>
+  <data name="SwitchBtn.Text" xml:space="preserve">
+    <value>エキスパートモード</value>
+  </data>
+  <data name="SwitchBtn.ToolTip" xml:space="preserve">
+    <value>エキスパートモードに切り替えます。より複雑になりますが、設定の柔軟性が向上します</value>
+  </data>
+  <data name="PreviewCtrl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>カスタムコマンド</value>
+  </data>
+  <data name="$this.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/Forms/RegexTesterForm.ja-JP.resx
+++ b/PathCopyCopySettings/UI/Forms/RegexTesterForm.ja-JP.resx
@@ -1,0 +1,265 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="IgnoreCaseChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 17</value>
+  </data>
+  <data name="IgnoreCaseChk.Text" xml:space="preserve">
+    <value>大文字小文字を区別しない(&I)</value>
+  </data>
+  <data name="IgnoreCaseChk.ToolTip" xml:space="preserve">
+    <value>正規表現を使用する際に大文字小文字を区別するかを指定します</value>
+  </data>
+  <data name="ReplacementTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>157, 45</value>
+  </data>
+  <data name="ReplacementTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>253, 20</value>
+  </data>
+  <data name="ReplacementTxt.ToolTip" xml:space="preserve">
+    <value>検索/置換操作に使用する置換式</value>
+  </data>
+  <data name="RegexTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>116, 19</value>
+  </data>
+  <data name="RegexTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>294, 20</value>
+  </data>
+  <data name="RegexTxt.ToolTip" xml:space="preserve">
+    <value>検索/置換操作に使用する正規表現</value>
+  </data>
+  <data name="ReplacementLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>145, 13</value>
+  </data>
+  <data name="ReplacementLbl.Text" xml:space="preserve">
+    <value>置換式(&R):</value>
+  </data>
+  <data name="ReplacementLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RegexLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 13</value>
+  </data>
+  <data name="RegexLbl.Text" xml:space="preserve">
+    <value>正規表現(&X):</value>
+  </data>
+  <data name="RegexLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ParamsGroupBox.Text" xml:space="preserve">
+    <value>パラメータ</value>
+  </data>
+  <data name="ParamsGroupBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="InvalidNoticeLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>169, 13</value>
+  </data>
+  <data name="InvalidNoticeLbl.Text" xml:space="preserve">
+    <value>無効な正規表現</value>
+  </data>
+  <data name="InvalidNoticeLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TestBtn.ToolTip" xml:space="preserve">
+    <value>提供された正規表現と置換式を使用して、サンプルに対して検索/置換操作を実行します</value>
+  </data>
+  <data name="ResultLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="ResultLbl.Text" xml:space="preserve">
+    <value>結果:</value>
+  </data>
+  <data name="ResultLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ResultTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>61, 67</value>
+  </data>
+  <data name="ResultTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>349, 20</value>
+  </data>
+  <data name="ResultTxt.ToolTip" xml:space="preserve">
+    <value>検索/置換操作の結果</value>
+  </data>
+  <data name="SampleTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>62, 41</value>
+  </data>
+  <data name="SampleTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>348, 20</value>
+  </data>
+  <data name="SampleTxt.ToolTip" xml:space="preserve">
+    <value>正規表現と置換式を適用するサンプルテキスト</value>
+  </data>
+  <data name="SampleLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="SampleLbl.Text" xml:space="preserve">
+    <value>サンプル(&P):</value>
+  </data>
+  <data name="SampleLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ExecutionExplanationLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>375, 13</value>
+  </data>
+  <data name="ExecutionExplanationLbl.Text" xml:space="preserve">
+    <value>正規表現をテストするには、サンプルを入力して「テスト」をクリックしてください。</value>
+  </data>
+  <data name="ExecutionExplanationLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ExecutionGroupBox.Text" xml:space="preserve">
+    <value>実行</value>
+  </data>
+  <data name="ExecutionGroupBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RegexSyntaxHelpLbl1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>399, 13</value>
+  </data>
+  <data name="RegexSyntaxHelpLbl1.Text" xml:space="preserve">
+    <value>Path Copy CopyはJavaScript/ECMAScriptの正規表現構文を使用します。</value>
+  </data>
+  <data name="RegexSyntaxHelpLbl1.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RegexSyntaxHelpLbl2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>285, 13</value>
+  </data>
+  <data name="RegexSyntaxHelpLbl2.Text" xml:space="preserve">
+    <value>正規表現に関する優れた参考資料:</value>
+  </data>
+  <data name="RegexSyntaxHelpLbl2.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CancelBtn.ToolTip" xml:space="preserve">
+    <value>正規表現と置換式を変更せずに元のダイアログに戻ります</value>
+  </data>
+  <data name="OKBtn.ToolTip" xml:space="preserve">
+    <value>正規表現と置換式の変更を元のダイアログにコピーしてウィンドウを閉じます</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>正規表現のテスト</value>
+  </data>
+  <data name="$this.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/Forms/SoftwareUpdateForm.ja-JP.resx
+++ b/PathCopyCopySettings/UI/Forms/SoftwareUpdateForm.ja-JP.resx
@@ -1,0 +1,175 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="SoftwareUpdateAvailLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>271, 13</value>
+  </data>
+  <data name="SoftwareUpdateAvailLbl.Text" xml:space="preserve">
+    <value>Path Copy Copyの新しいバージョンが利用可能です:</value>
+  </data>
+  <data name="SoftwareUpdateTitleLbl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>289, 9</value>
+  </data>
+  <data name="SoftwareUpdateTitleLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 13</value>
+  </data>
+  <data name="SoftwareUpdateTitleLbl.Text" xml:space="preserve">
+    <value>&lt;アップデート名&gt;</value>
+  </data>
+  <data name="SoftwareUpdateUrlLinkLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>293, 13</value>
+  </data>
+  <data name="SoftwareUpdateUrlLinkLbl.Text" xml:space="preserve">
+    <value>ここをクリックしてウェブサイトにアクセスし、アップデートをダウンロードしてください</value>
+  </data>
+  <data name="ReleaseNotesWebBrowser.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 56</value>
+  </data>
+  <data name="ReleaseNotesWebBrowser.Size" type="System.Drawing.Size, System.Drawing">
+    <value>362, 283</value>
+  </data>
+  <data name="ReleaseNotesLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 13</value>
+  </data>
+  <data name="ReleaseNotesLbl.Text" xml:space="preserve">
+    <value>リリースノート:</value>
+  </data>
+  <data name="CloseBtn.Text" xml:space="preserve">
+    <value>閉じる(&F)</value>
+  </data>
+  <data name="CloseBtn.ToolTip" xml:space="preserve">
+    <value>アップデートを適用せずにウィンドウを閉じます。後で再度提供されます</value>
+  </data>
+  <data name="IgnoreUpdateBtn.Location" type="System.Drawing.Point, System.Drawing">
+    <value>241, 345</value>
+  </data>
+  <data name="IgnoreUpdateBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>148, 23</value>
+  </data>
+  <data name="IgnoreUpdateBtn.Text" xml:space="preserve">
+    <value>このアップデートを無視(&I)</value>
+  </data>
+  <data name="IgnoreUpdateBtn.ToolTip" xml:space="preserve">
+    <value>このアップデートをインストールしません。より新しいアップデートが提供されない限り、再度通知されません</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Path Copy Copyのアップデートが利用可能です</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/CommandLinePipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/CommandLinePipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,133 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArgumentsTxt.ToolTip" xml:space="preserve">
+    <value>実行ファイルに渡す引数。%FILES%が含まれている場合はパスに置き換えられ、含まれていない場合はパスが末尾に追加されます</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="UseFilelistChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 17</value>
+  </data>
+  <data name="UseFilelistChk.Text" xml:space="preserve">
+    <value>リストファイルを使用(&F)</value>
+  </data>
+  <data name="UseFilelistChk.ToolTip" xml:space="preserve">
+    <value>パスを実行ファイルに直接渡すか(チェックなし)、リストファイル経由で渡すか(チェックあり)を指定します</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/ConfiglessPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/ConfiglessPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ConfiglessLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>235, 13</value>
+  </data>
+  <data name="ConfiglessLbl.Text" xml:space="preserve">
+    <value>追加の設定は必要ありません。</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>235, 17</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/CopyNPathPartsPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/CopyNPathPartsPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,160 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="NumPartsTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>70, 0</value>
+  </data>
+  <data name="NumPartsTxt.ToolTip" xml:space="preserve">
+    <value>コピーするパスの部分の数</value>
+  </data>
+  <data name="CopyTheNLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="CopyTheNLbl.Text" xml:space="preserve">
+    <value>コピー(&C)</value>
+  </data>
+  <data name="FirstLastCombo.Items" xml:space="preserve">
+    <value>最初</value>
+  </data>
+  <data name="FirstLastCombo.Items1" xml:space="preserve">
+    <value>最後</value>
+  </data>
+  <data name="FirstLastCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>114, 0</value>
+  </data>
+  <data name="FirstLastCombo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 21</value>
+  </data>
+  <data name="FirstLastCombo.ToolTip" xml:space="preserve">
+    <value>パスの最初の部分と最後の部分のどちらをコピーするかを指定します</value>
+  </data>
+  <data name="PathPartsLbl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>195, 3</value>
+  </data>
+  <data name="PathPartsLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 13</value>
+  </data>
+  <data name="PathPartsLbl.Text" xml:space="preserve">
+    <value>個のパス部分</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>294, 25</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/DisplayForSelectionPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/DisplayForSelectionPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ShowForFilesCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>372, 17</value>
+  </data>
+  <data name="ShowForFilesCheck.Text" xml:space="preserve">
+    <value>ファイルが選択されている時にメニューにコマンドを表示(&F)</value>
+  </data>
+  <data name="ShowForFilesCheck.ToolTip" xml:space="preserve">
+    <value>ファイルが選択されている時にメニューにコマンドを表示するかを指定します</value>
+  </data>
+  <data name="ShowForFoldersCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>377, 17</value>
+  </data>
+  <data name="ShowForFoldersCheck.Text" xml:space="preserve">
+    <value>フォルダが選択されている時にメニューにコマンドを表示(&D)</value>
+  </data>
+  <data name="ShowForFoldersCheck.ToolTip" xml:space="preserve">
+    <value>フォルダが選択されている時にメニューにコマンドを表示するかを指定します</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>380, 45</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/FindReplacePipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/FindReplacePipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,151 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="FindLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 13</value>
+  </data>
+  <data name="FindLbl.Text" xml:space="preserve">
+    <value>検索(&H):</value>
+  </data>
+  <data name="ReplaceLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 13</value>
+  </data>
+  <data name="ReplaceLbl.Text" xml:space="preserve">
+    <value>置換(&R):</value>
+  </data>
+  <data name="ReplaceTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>82, 26</value>
+  </data>
+  <data name="ReplaceTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 20</value>
+  </data>
+  <data name="ReplaceTxt.ToolTip" xml:space="preserve">
+    <value>パス内で見つかった文字列を置き換えるために使用する文字列</value>
+  </data>
+  <data name="FindTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>56, 0</value>
+  </data>
+  <data name="FindTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 20</value>
+  </data>
+  <data name="FindTxt.ToolTip" xml:space="preserve">
+    <value>パス内で検索する文字列</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/InjectDriveLabelPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/InjectDriveLabelPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="InjectDriveLabelInstructionsLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>349, 13</value>
+  </data>
+  <data name="InjectDriveLabelInstructionsLbl.Text" xml:space="preserve">
+    <value>%DRIVELABEL%はドライブのラベルに置き換えられます。</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>349, 18</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/PathsSeparatorPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/PathsSeparatorPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,136 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="SeparatorLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 13</value>
+  </data>
+  <data name="SeparatorLbl.Text" xml:space="preserve">
+    <value>区切り文字(&S):</value>
+  </data>
+  <data name="SeparatorTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>65, 0</value>
+  </data>
+  <data name="SeparatorTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>166, 20</value>
+  </data>
+  <data name="SeparatorTxt.ToolTip" xml:space="preserve">
+    <value>複数のコピーされたパスを区切るために使用する文字列。デフォルト値(この要素が存在しない場合)は改行です</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/PipelineElementWithExecutableUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/PipelineElementWithExecutableUserControl.ja-JP.resx
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExecutableLbl.Text" xml:space="preserve">
+    <value>実行ファイル(&X):</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ExecutableTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 2</value>
+  </data>
+  <data name="ExecutableTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>166, 20</value>
+  </data>
+  <data name="ExecutableTxt.ToolTip" xml:space="preserve">
+    <value>起動する実行ファイル</value>
+  </data>
+  <data name="BrowseForExecutableBtn.Text" xml:space="preserve">
+    <value>参照(&P)...</value>
+  </data>
+  <data name="BrowseForExecutableBtn.ToolTip" xml:space="preserve">
+    <value>起動する実行ファイルを選択するダイアログを開きます</value>
+  </data>
+  <data name="ChooseExecutableOpenDlg.Filter" xml:space="preserve">
+    <value>実行ファイル (*.exe;*.com;*.bat;*.cmd)|*.exe;*.com;*.bat;*.cmd|すべてのファイル (*.*)|*.*</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/PipelineElementWithPluginIDUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/PipelineElementWithPluginIDUserControl.ja-JP.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BasePluginLst.ToolTip" xml:space="preserve">
+    <value>パスを取得するために使用するベースコマンド</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/PluginPreviewUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/PluginPreviewUserControl.ja-JP.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PreviewGroupBox.Text" xml:space="preserve">
+    <value>プレビュー</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/PopFromStackPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/PopFromStackPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,238 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="PopValueAndLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>108, 13</value>
+  </data>
+  <data name="PopValueAndLbl.Text" xml:space="preserve">
+    <value>値をポップして:</value>
+  </data>
+  <data name="PopValueAndLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="EntireRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 17</value>
+  </data>
+  <data name="EntireRadio.Text" xml:space="preserve">
+    <value>パス全体を置換(&E)</value>
+  </data>
+  <data name="EntireRadio.ToolTip" xml:space="preserve">
+    <value>パス全体をポップした値で置き換えます</value>
+  </data>
+  <data name="RangeRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>268, 17</value>
+  </data>
+  <data name="RangeRadio.Text" xml:space="preserve">
+    <value>位置の範囲でパスの内容を置換(&P)</value>
+  </data>
+  <data name="RangeRadio.ToolTip" xml:space="preserve">
+    <value>指定された範囲内のパスの文字をポップした値で置き換えます</value>
+  </data>
+  <data name="RangeBeginTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>274, 38</value>
+  </data>
+  <data name="RangeBeginTxt.ToolTip" xml:space="preserve">
+    <value>ポップした値で置き換える範囲の開始位置</value>
+  </data>
+  <data name="BeginAndEndLbl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>307, 41</value>
+  </data>
+  <data name="BeginAndEndLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 13</value>
+  </data>
+  <data name="BeginAndEndLbl.Text" xml:space="preserve">
+    <value>～</value>
+  </data>
+  <data name="BeginAndEndLbl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RangeEndTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>329, 38</value>
+  </data>
+  <data name="RangeEndTxt.ToolTip" xml:space="preserve">
+    <value>ポップした値で置き換える範囲の終了位置</value>
+  </data>
+  <data name="RegexRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>245, 17</value>
+  </data>
+  <data name="RegexRadio.Text" xml:space="preserve">
+    <value>正規表現が見つけたものを置換(&R)</value>
+  </data>
+  <data name="RegexRadio.ToolTip" xml:space="preserve">
+    <value>正規表現で見つかった文字をポップした値で置き換えます</value>
+  </data>
+  <data name="RegexTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 61</value>
+  </data>
+  <data name="RegexTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 20</value>
+  </data>
+  <data name="RegexTxt.ToolTip" xml:space="preserve">
+    <value>ポップした値で置き換えるパスの部分を特定するために使用する正規表現</value>
+  </data>
+  <data name="IgnoreCaseChk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>188, 91</value>
+  </data>
+  <data name="IgnoreCaseChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 17</value>
+  </data>
+  <data name="IgnoreCaseChk.Text" xml:space="preserve">
+    <value>大文字小文字を区別しない(&I)</value>
+  </data>
+  <data name="IgnoreCaseChk.ToolTip" xml:space="preserve">
+    <value>正規表現を使用してポップした値で置き換えるパスの部分を特定する際に、大文字小文字を区別するかを指定します</value>
+  </data>
+  <data name="TestRegexBtn.Text" xml:space="preserve">
+    <value>テスト(&T)...</value>
+  </data>
+  <data name="TestRegexBtn.ToolTip" xml:space="preserve">
+    <value>正規表現をテストするダイアログを開きます</value>
+  </data>
+  <data name="StartRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>197, 17</value>
+  </data>
+  <data name="StartRadio.Text" xml:space="preserve">
+    <value>パスの先頭に値を挿入(&B)</value>
+  </data>
+  <data name="StartRadio.ToolTip" xml:space="preserve">
+    <value>ポップした値をパスの先頭に挿入します</value>
+  </data>
+  <data name="EndRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 17</value>
+  </data>
+  <data name="EndRadio.Text" xml:space="preserve">
+    <value>パスの末尾に値を挿入(&F)</value>
+  </data>
+  <data name="EndRadio.ToolTip" xml:space="preserve">
+    <value>ポップした値をパスの末尾に挿入します</value>
+  </data>
+  <data name="NowhereRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 17</value>
+  </data>
+  <data name="NowhereRadio.Text" xml:space="preserve">
+    <value>値に対して何もしない(&A)</value>
+  </data>
+  <data name="NowhereRadio.ToolTip" xml:space="preserve">
+    <value>ポップした値に対して何もしません(単に無視します)</value>
+  </data>
+  <data name="$this.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/PushToStackPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/PushToStackPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,223 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="PushToStackLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 13</value>
+  </data>
+  <data name="PushToStackLbl.Text" xml:space="preserve">
+    <value>プッシュ:</value>
+  </data>
+  <data name="EntirePathRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="EntirePathRadio.Text" xml:space="preserve">
+    <value>パス全体(&E)</value>
+  </data>
+  <data name="EntirePathRadio.ToolTip" xml:space="preserve">
+    <value>完全なパスをプッシュします</value>
+  </data>
+  <data name="RangeRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>218, 17</value>
+  </data>
+  <data name="RangeRadio.Text" xml:space="preserve">
+    <value>位置の範囲でパスの内容(&P)</value>
+  </data>
+  <data name="RangeRadio.ToolTip" xml:space="preserve">
+    <value>範囲で定義されたパスの一部をプッシュします</value>
+  </data>
+  <data name="RangeBeginTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>224, 38</value>
+  </data>
+  <data name="RangeBeginTxt.ToolTip" xml:space="preserve">
+    <value>プッシュする範囲の開始位置</value>
+  </data>
+  <data name="BeginAndEndLbl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>257, 41</value>
+  </data>
+  <data name="BeginAndEndLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 13</value>
+  </data>
+  <data name="BeginAndEndLbl.Text" xml:space="preserve">
+    <value>～</value>
+  </data>
+  <data name="RangeEndTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 38</value>
+  </data>
+  <data name="RangeEndTxt.ToolTip" xml:space="preserve">
+    <value>プッシュする範囲の終了位置</value>
+  </data>
+  <data name="RegexRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 17</value>
+  </data>
+  <data name="RegexRadio.Text" xml:space="preserve">
+    <value>正規表現が見つけたもの(&R)</value>
+  </data>
+  <data name="RegexRadio.ToolTip" xml:space="preserve">
+    <value>正規表現で見つかったものをプッシュします</value>
+  </data>
+  <data name="RegexTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>198, 61</value>
+  </data>
+  <data name="RegexTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>172, 20</value>
+  </data>
+  <data name="RegexTxt.ToolTip" xml:space="preserve">
+    <value>プッシュするパスの部分を見つけるために使用する正規表現</value>
+  </data>
+  <data name="IgnoreCaseChk.ToolTip" xml:space="preserve">
+    <value>正規表現を使用してプッシュするパスの部分を見つける際に、大文字小文字を区別するかを指定します</value>
+  </data>
+  <data name="TestRegexBtn.ToolTip" xml:space="preserve">
+    <value>正規表現をテストするダイアログを開きます</value>
+  </data>
+  <data name="UseGroupLbl1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 13</value>
+  </data>
+  <data name="UseGroupLbl1.Text" xml:space="preserve">
+    <value>(グループを使用(&G)</value>
+  </data>
+  <data name="RegexGroupTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>113, 89</value>
+  </data>
+  <data name="RegexGroupTxt.ToolTip" xml:space="preserve">
+    <value>プッシュする正規表現で見つかったグループ</value>
+  </data>
+  <data name="UseGroupLbl2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>146, 92</value>
+  </data>
+  <data name="FixedStringRadio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
+  </data>
+  <data name="FixedStringRadio.Text" xml:space="preserve">
+    <value>値(&V)</value>
+  </data>
+  <data name="FixedStringRadio.ToolTip" xml:space="preserve">
+    <value>固定値をプッシュします</value>
+  </data>
+  <data name="FixedStringTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>75, 114</value>
+  </data>
+  <data name="FixedStringTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>295, 20</value>
+  </data>
+  <data name="FixedStringTxt.ToolTip" xml:space="preserve">
+    <value>プッシュする値</value>
+  </data>
+</root>

--- a/PathCopyCopySettings/UI/UserControls/RegexPipelineElementUserControl.ja-JP.resx
+++ b/PathCopyCopySettings/UI/UserControls/RegexPipelineElementUserControl.ja-JP.resx
@@ -1,0 +1,166 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="FindLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 13</value>
+  </data>
+  <data name="FindLbl.Text" xml:space="preserve">
+    <value>正規表現(&X):</value>
+  </data>
+  <data name="ReplaceLbl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>145, 13</value>
+  </data>
+  <data name="ReplaceLbl.Text" xml:space="preserve">
+    <value>置換式(&R):</value>
+  </data>
+  <data name="ReplaceTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>148, 26</value>
+  </data>
+  <data name="ReplaceTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 20</value>
+  </data>
+  <data name="ReplaceTxt.ToolTip" xml:space="preserve">
+    <value>正規表現で見つかった要素を置き換えるために使用する式</value>
+  </data>
+  <data name="FindTxt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 0</value>
+  </data>
+  <data name="FindTxt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 20</value>
+  </data>
+  <data name="FindTxt.ToolTip" xml:space="preserve">
+    <value>パスに対して使用する正規表現</value>
+  </data>
+  <data name="IgnoreCaseChk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 17</value>
+  </data>
+  <data name="IgnoreCaseChk.Text" xml:space="preserve">
+    <value>大文字小文字を区別しない(&I)</value>
+  </data>
+  <data name="IgnoreCaseChk.ToolTip" xml:space="preserve">
+    <value>正規表現を使用する際に大文字小文字を区別するかを指定します</value>
+  </data>
+  <data name="TestBtn.Text" xml:space="preserve">
+    <value>テスト(&T)...</value>
+  </data>
+  <data name="TestBtn.ToolTip" xml:space="preserve">
+    <value>正規表現と置換式をテストするダイアログを開きます</value>
+  </data>
+</root>


### PR DESCRIPTION
This PR adds complete Japanese localization for Path Copy Copy.

## Changes:
- Added 19 Japanese localization files for UI components (*.ja-JP.resx)
- Added Japanese localization for Resources (Resources.ja-JP.resx)
- Updated Resources.resx to include Japanese language entries

All files are saved as UTF-8 with BOM.